### PR TITLE
Fix 22: Link components and patterns to backlog

### DIFF
--- a/app/views/components/add-another/README.md
+++ b/app/views/components/add-another/README.md
@@ -29,4 +29,4 @@ This component has been tested in prototypes of several citizen and internal pro
 
 ## Contribute to this component
 
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/)
+You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/6)

--- a/app/views/components/badge/README.md
+++ b/app/views/components/badge/README.md
@@ -194,4 +194,4 @@ This component has been used successfully in the following services:
 
 ## Contribute to this component
 
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/)
+You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/26)

--- a/app/views/components/banner/README.md
+++ b/app/views/components/banner/README.md
@@ -60,4 +60,4 @@ If you have used the banner component, get in touch to share your research findi
 
 ## Contribute to this component
 
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/)
+You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/36)

--- a/app/views/components/currency-input/README.md
+++ b/app/views/components/currency-input/README.md
@@ -30,4 +30,4 @@ This component has been used successfully in the following services:
 
 ## Contribute to this component
 
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/)
+You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/9)

--- a/app/views/components/filter/README.md
+++ b/app/views/components/filter/README.md
@@ -24,4 +24,4 @@ If you have used the filter component, get in touch to share your research findi
 
 ## Contribute to this component
 
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/)
+You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/2)

--- a/app/views/components/form-validator/README.md
+++ b/app/views/components/form-validator/README.md
@@ -20,4 +20,4 @@ We need more research. If you have used the form validator component, get in tou
 
 ## Contribute to this component
 
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/)
+You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/37)

--- a/app/views/components/header/README.md
+++ b/app/views/components/header/README.md
@@ -20,4 +20,4 @@ We need more research. If you have used the header component, get in touch to sh
 
 ## Contribute to this component
 
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/)
+You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/7)

--- a/app/views/components/identity-bar/README.md
+++ b/app/views/components/identity-bar/README.md
@@ -54,4 +54,4 @@ We need more research. If you have used the identity bar component, get in touch
 
 ## Contribute to this component
 
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/)
+You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/38)

--- a/app/views/components/menu/README.md
+++ b/app/views/components/menu/README.md
@@ -49,4 +49,4 @@ We need more research. If you have used the menu component, get in touch to shar
 
 ## Contribute to this component
 
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/)
+You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/39)

--- a/app/views/components/messages/README.md
+++ b/app/views/components/messages/README.md
@@ -23,4 +23,4 @@ This component has been used in:
 
 ## Contribute to this component
 
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/)
+You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/14)

--- a/app/views/components/multi-file-upload/README.md
+++ b/app/views/components/multi-file-upload/README.md
@@ -96,4 +96,4 @@ If you have used the multi file upload component, get in touch to share your res
 
 ## Contribute to this component
 
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/)
+You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/1)

--- a/app/views/components/multi-select/README.md
+++ b/app/views/components/multi-select/README.md
@@ -27,4 +27,4 @@ We need more research. If you have used the multi select component, get in touch
 
 ## Contribute to this component
 
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/)
+You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/40)

--- a/app/views/components/notification-badge/README.md
+++ b/app/views/components/notification-badge/README.md
@@ -32,4 +32,4 @@ We need more research. If you have used the notification badge component, get in
 
 ## Contribute to this component
 
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/)
+You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/41)

--- a/app/views/components/organisation-switcher/README.md
+++ b/app/views/components/organisation-switcher/README.md
@@ -24,4 +24,4 @@ We need more research. If you have used the organisation switcher component, get
 
 ## Contribute to this component
 
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/)
+You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/3)

--- a/app/views/components/page-header-actions/README.md
+++ b/app/views/components/page-header-actions/README.md
@@ -27,4 +27,4 @@ We need more research. If you have used the page header actions component, get i
 
 ## Contribute to this component
 
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/)
+You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/42)

--- a/app/views/components/pagination/README.md
+++ b/app/views/components/pagination/README.md
@@ -28,4 +28,4 @@ We need more research. If you have used the pagination component, get in touch t
 
 ## Contribute to this component
 
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/)
+You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/13)

--- a/app/views/components/password-reveal/README.md
+++ b/app/views/components/password-reveal/README.md
@@ -16,4 +16,4 @@ We need more research. If you have used the password reveal component, get in to
 
 ## Contribute to this component
 
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/)
+You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/43)

--- a/app/views/components/primary-navigation/README.md
+++ b/app/views/components/primary-navigation/README.md
@@ -42,4 +42,4 @@ We need more research. If you have used the primary navigation component, get in
 
 ## Contribute to this component
 
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/)
+You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/46)

--- a/app/views/components/rich-text-editor/README.md
+++ b/app/views/components/rich-text-editor/README.md
@@ -29,4 +29,4 @@ We need more research. If you have used the rich text editor component, get in t
 
 ## Contribute to this component
 
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/)
+You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/44)

--- a/app/views/components/search/README.md
+++ b/app/views/components/search/README.md
@@ -18,4 +18,4 @@ We need more research. If you have used the search component, get in touch to sh
 
 ## Contribute to this component
 
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/)
+You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/24)

--- a/app/views/components/sortable-table/README.md
+++ b/app/views/components/sortable-table/README.md
@@ -30,4 +30,4 @@ We need more research. If you have used the sortable table component, get in tou
 
 ## Contribute to this component
 
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/)
+You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/23)

--- a/app/views/components/sub-navigation/README.md
+++ b/app/views/components/sub-navigation/README.md
@@ -24,4 +24,4 @@ We need more research. If you have used the sub navigation component, get in tou
 
 ## Contribute to this component
 
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/)
+You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/4)

--- a/app/views/components/tag/README.md
+++ b/app/views/components/tag/README.md
@@ -123,4 +123,4 @@ We need more research. If you have used alternative tag styles, get in touch to 
 
 ## Contribute to these styles
 
-You can contribute to these styles via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/)
+You can contribute to these styles via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/26)

--- a/app/views/components/timeline/README.md
+++ b/app/views/components/timeline/README.md
@@ -16,4 +16,4 @@ We need more research. If you have used the timeline component, get in touch to 
 
 ## Contribute to this component
 
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/)
+You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/45)

--- a/app/views/patterns/accessibility-statement/README.md
+++ b/app/views/patterns/accessibility-statement/README.md
@@ -1,7 +1,7 @@
 
 Any websites published since September 2018 need to meet accessibility standards and publish an accessibility statement.
 
-HMCTS will need to publish accessibility statements for each service, which will be linked from the service footer.
+MOJ will need to publish accessibility statements for each service, which will be linked from the service footer.
 
 ## What the statement needs to cover
 
@@ -14,7 +14,6 @@ The statement must:
 - explain the procedure if people are not happy with the response
 - be in an accessible and consistent format
 - be updated annually
-
 
 ## Accessibility statement template
 
@@ -36,7 +35,6 @@ You should include users with access needs and those using assistive technologie
 
 When fixing issues with your online services and published content make sure they meet the key acceptance criteria of the European or international standards (respectively, [EN 301 549](http://mandate376.standards.eu/standard) and [WCAG 2.1 AA](https://www.w3.org/TR/WCAG21/)).
 
-
 ## Background
 
 The Public Sector Bodies (Websites and Mobile Applications) (No.2) Accessibility Regulations 2018 came into force on 23 September 2018. It aims to ensure public sector websites and mobile apps are accessible to all users, especially those with disabilities.
@@ -44,3 +42,7 @@ The Public Sector Bodies (Websites and Mobile Applications) (No.2) Accessibility
 Any websites published since September 2018 will need a statement by September 2019, while older websites have until 2020 to comply.
 
 [Public sector website accessibility statements - what you need to know](https://gds.blog.gov.uk/2018/11/21/public-sector-website-accessibility-statements-what-you-need-to-know/).
+
+## Contribute to this pattern
+
+You can contribute to this pattern via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/50)

--- a/app/views/patterns/be-informed-of-downtime/README.md
+++ b/app/views/patterns/be-informed-of-downtime/README.md
@@ -18,4 +18,4 @@ We need more research. If you have used the support, get in touch to share your 
 
 ## Contribute to this pattern
 
-You can contribute to this pattern via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/)
+You can contribute to this pattern via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/52)

--- a/app/views/patterns/cookie-policy/README.md
+++ b/app/views/patterns/cookie-policy/README.md
@@ -9,18 +9,16 @@ You may be able to use this content without any changes. Check with your technic
   height: 2315
 }) }}
 
-## Guidance
-
-### When to use this pattern
+## When to use this pattern
 
 Every service for citizens and professional users needs a cookie policy. Services for staff and the judiciary may not need them.
 
 If you need a cookie policy, link to it from the footer.
 
-### Research on this pattern
+## Research on this pattern
 
 We need more research. If you have used this cookie policy, get in touch to share your research findings.
 
 ## Contribute to this pattern
 
-You can contribute to this pattern via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/)
+You can contribute to this pattern via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/49)

--- a/app/views/patterns/filter-a-list/README.md
+++ b/app/views/patterns/filter-a-list/README.md
@@ -31,8 +31,8 @@ Filters can be used in combination with [search](/components/search/). In this c
 
 ## Research on this pattern.
 
-We need more research. If you have used the filter pattern, get in touch to share your research findings.
+We need more research. If you have used the filter a list pattern, get in touch to share your research findings.
 
 ## Contribute to this pattern
 
-You can contribute to this pattern via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/)
+You can contribute to this pattern via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/2)

--- a/app/views/patterns/get-help/README.md
+++ b/app/views/patterns/get-help/README.md
@@ -45,4 +45,4 @@ We need more research. If you have used the support, get in touch to share your 
 
 ## Contribute to this pattern
 
-You can contribute to this pattern via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/)
+You can contribute to this pattern via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/47)

--- a/app/views/patterns/manage-a-list/README.md
+++ b/app/views/patterns/manage-a-list/README.md
@@ -30,10 +30,10 @@ When items are within a table, the select all button should be in the first tabl
 
 ## Research on this pattern
 
-We need more research. If you have used the support, get in touch to share your research findings.
+We need more research. If you have used the manage a list pattern, get in touch to share your research findings.
 
 ## Contribute to this pattern
 
-You can contribute to this pattern via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/)
+You can contribute to this pattern via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/40)
 
 

--- a/app/views/patterns/privacy-policy/README.md
+++ b/app/views/patterns/privacy-policy/README.md
@@ -11,9 +11,7 @@ Edit the content to make it specific to your service. Check with your product ow
   height: 1840
 }) }}
 
-## Guidance
-
-### When to use this pattern
+## When to use this pattern
 
 Every service for citizens and professional users needs a privacy policy. Services for staff and the judiciary may not need it.
 
@@ -21,14 +19,14 @@ If you need a privacy policy, link to it from the footer.
 
 You may also need to link to the privacy policy from within a user journey. Check with your product owner whether you need to do this for GDPR compliance.
 
-### Legal review
+## Legal review
 
 The template been reviewed by a legal team including GDPR specialists.
 
-### Research on this pattern
+## Research on this pattern
 
 We need more research. If you have used this privacy policy, get in touch to share your research findings.
 
 ## Contribute to this pattern
 
-You can contribute to this pattern via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/)
+You can contribute to this pattern via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/48)

--- a/app/views/patterns/search-for-something/README.md
+++ b/app/views/patterns/search-for-something/README.md
@@ -23,8 +23,8 @@ Don't provide users with an advanced search page. Users prefer to search and _th
 
 ## Research on this pattern
 
-More research is needed on this.
+We need more research. If you have used the search pattern, get in touch to share your research findings.
 
 ## Contribute to this pattern
 
-You can contribute to this pattern via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/)
+You can contribute to this pattern via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/24)

--- a/app/views/patterns/take-action/README.md
+++ b/app/views/patterns/take-action/README.md
@@ -47,8 +47,8 @@ Don't put actions within the [primary navigation](/components/primary-navigation
 
 ## Research on this pattern
 
-More research is needed on this pattern.
+We need more research. If you have used this pattern, get in touch to share your research findings.
 
 ## Contribute to this pattern
 
-You can contribute to this pattern via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/)
+You can contribute to this pattern via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/38)

--- a/app/views/patterns/terms-and-conditions/README.md
+++ b/app/views/patterns/terms-and-conditions/README.md
@@ -27,5 +27,5 @@ We need more research. If you have used these terms and conditions, get in touch
 
 ## Contribute to this pattern
 
-You can contribute to this pattern via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/)
+You can contribute to this pattern via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/51)
 

--- a/app/views/patterns/upload-files/README.md
+++ b/app/views/patterns/upload-files/README.md
@@ -96,6 +96,12 @@ If you do this, you can store the original file and give users the option to vie
 
 Use the [file upload error messages from the GOV.UK Design System](https://design-system.service.gov.uk/components/file-upload/#error-messages).
 
+## Research on this pattern
+
+This pattern is marked as experimental because it needs more research.
+
+If you have used the file upload pattern, get in touch to share your research findings.
+
 ## Contribute to this pattern
 
-You can contribute to this pattern via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/)
+You can contribute to this pattern via the [design system backlog](https://github.com/ministryofjustice/mojdt-design-system-backlog/issues/1)


### PR DESCRIPTION
Fix issue #22 – linking components and patterns in the design system to equivalent issues in the community backlog.